### PR TITLE
Update to vertx 5 API

### DIFF
--- a/bom/project-bom/pom.xml
+++ b/bom/project-bom/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <!-- Dependency versions -->
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.io.netty.netty>4.2.4.Final</version.io.netty.netty>
+        <version.io.netty.netty>4.2.5.Final</version.io.netty.netty>
         <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
     </properties>
 

--- a/client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
+++ b/client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
@@ -202,9 +202,9 @@ public class VertxClientHttpEngine implements AsyncClientHttpEngine {
                         }
                     };
                     if (body != null) {
-                        httpClientRequest.send(body, handler);
+                        httpClientRequest.send(body).onComplete(handler);
                     } else {
-                        httpClientRequest.send(handler);
+                        httpClientRequest.send().onComplete(handler);
                     }
                     return null;
                 })

--- a/client/src/test/java/org/jboss/resteasy/test/client/vertx/VertxClientEngineTest.java
+++ b/client/src/test/java/org/jboss/resteasy/test/client/vertx/VertxClientEngineTest.java
@@ -74,7 +74,7 @@ public class VertxClientEngineTest {
             client.close();
         }
         CountDownLatch latch = new CountDownLatch(1);
-        vertx.close(ar -> latch.countDown());
+        vertx.close().onComplete(ar -> latch.countDown());
         latch.await(2, TimeUnit.MINUTES);
         executorService.shutdownNow();
     }
@@ -82,7 +82,7 @@ public class VertxClientEngineTest {
     private Client client() throws Exception {
         if (server.actualPort() == 0) {
             CompletableFuture<Void> fut = new CompletableFuture<>();
-            server.listen(0, ar -> {
+            server.listen(0).onComplete(ar -> {
                 if (ar.succeeded()) {
                     fut.complete(null);
                 } else {
@@ -368,7 +368,7 @@ public class VertxClientEngineTest {
     @Test
     public void testServerFailure1() throws Exception {
         server.requestHandler(req -> {
-            req.response().close();
+            req.response().reset();
         });
 
         try {
@@ -386,7 +386,7 @@ public class VertxClientEngineTest {
             resp.setChunked(true).write("something");
             vertx.setTimer(1000, id -> {
                 // Leave it some time to receive the response headers and start processing the response
-                resp.close();
+                resp.reset();
             });
         });
 

--- a/client/src/test/java/org/jboss/resteasy/test/client/vertx/VertxSslClientEngineTest.java
+++ b/client/src/test/java/org/jboss/resteasy/test/client/vertx/VertxSslClientEngineTest.java
@@ -57,7 +57,7 @@ public class VertxSslClientEngineTest {
         });
         if (server.actualPort() == 0) {
             CompletableFuture<Void> fut = new CompletableFuture<>();
-            server.listen(0, ar -> {
+            server.listen(0).onComplete(ar -> {
                 if (ar.succeeded()) {
                     fut.complete(null);
                 } else {
@@ -71,7 +71,7 @@ public class VertxSslClientEngineTest {
     @AfterEach
     public void stop() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        vertx.close(ar -> latch.countDown());
+        vertx.close().onComplete(ar -> latch.countDown());
         latch.await(2, TimeUnit.MINUTES);
         executorService.shutdownNow();
         if (certificate != null) {

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -393,16 +393,16 @@ public class VertxHttpRequest extends BaseHttpRequest {
                     suspend();
                 }
                 CompletableFuture<Void> ret = new CompletableFuture<>();
-                this.request.context.executeBlocking(future -> {
+                this.request.context.executeBlocking(() -> {
                     try (CloseableContext newContext = ResteasyContext.addCloseableContextDataLevel(context)) {
                         f.run();
-                        future.complete();
+                        return null;
                     } catch (RuntimeException e) {
                         throw e;
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                }, res -> {
+                }).onComplete(res -> {
                     if (res.succeeded())
                         ret.complete(null);
                     else

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
@@ -82,7 +82,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
         DeploymentOptions deploymentOptions = new DeploymentOptions()
                 .setInstances(vertxOptions.getEventLoopPoolSize())
                 .setConfig(new JsonObject().put("helper", key));
-        vertx.deployVerticle(Verticle.class.getName(), deploymentOptions, ar -> {
+        vertx.deployVerticle(Verticle.class.getName(), deploymentOptions).onComplete(ar -> {
             deploymentMap.remove(key);
             if (ar.succeeded()) {
                 fut.complete(ar.result());
@@ -106,7 +106,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
     public void stop() {
         if (deploymentID != null) {
             CompletableFuture<Void> fut = new CompletableFuture<>();
-            vertx.close(ar -> {
+            vertx.close().onComplete(ar -> {
                 fut.complete(null);
             });
             deploymentID = null;
@@ -229,7 +229,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
             Helper helper = deploymentMap.get(config().getString("helper"));
             server = vertx.createHttpServer(helper.serverOptions);
             server.requestHandler(new VertxRequestHandler(vertx, helper.deployment, helper.root, helper.domain));
-            server.listen(ar -> {
+            server.listen().onComplete(ar -> {
                 if (ar.succeeded()) {
                     startPromise.complete();
                 } else {

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.plugins.server.vertx;
 
 import java.io.IOException;
 
+import io.vertx.core.internal.buffer.BufferInternal;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
 import org.jboss.resteasy.plugins.server.vertx.i18n.LogMessages;
@@ -57,7 +58,8 @@ public class VertxRequestHandler implements Handler<HttpServerRequest> {
             VertxHttpRequest vertxRequest = new VertxHttpRequest(ctx, request, uriInfo, dispatcher.getDispatcher(),
                     vertxResponse, false);
             if (buff.length() > 0) {
-                ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
+                BufferInternal bufferInternal = (BufferInternal) buff;
+                ByteBufInputStream in = new ByteBufInputStream(bufferInternal.getByteBuf());
                 vertxRequest.setInputStream(in);
             }
 

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxUtil.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxUtil.java
@@ -33,7 +33,7 @@ public class VertxUtil {
         if (uri.startsWith(protocol + "://")) {
             uriString = uri;
         } else {
-            String host = req.host();
+            String host = req.authority().host();
             if (host == null) {
                 host = "unknown";
             }

--- a/embedded-server/src/test/java/org/jboss/resteasy/test/DeploymentTest.java
+++ b/embedded-server/src/test/java/org/jboss/resteasy/test/DeploymentTest.java
@@ -86,7 +86,7 @@ public class DeploymentTest {
             server = vertx.createHttpServer();
             server.requestHandler(new VertxRequestHandler(vertx, deployment));
             CompletableFuture<Void> listenLatch = new CompletableFuture<>();
-            server.listen(TestPortProvider.getPort(), ar -> {
+            server.listen(TestPortProvider.getPort()).onComplete(ar -> {
                 if (ar.succeeded()) {
                     listenLatch.complete(null);
                 } else {

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven.min.version>3.9.0</maven.min.version>
 
         <!-- Dependency versions -->
-        <version.io.vertx>4.5.13</version.io.vertx>
+        <version.io.vertx>5.0.4</version.io.vertx>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
 


### PR DESCRIPTION
This is the same as the PR that was made on the original resteasy repo  ([link](https://github.com/resteasy/resteasy/pull/4604)). 
There is a relevant JIRA ticket here: https://issues.redhat.com/browse/RESTEASY-3597

This PR updates the Vertx client and server adapter to use Vertx 5. Majority of the PR is simply replacing the Vertx 4 callback pattern with the equivalent Future + onComplete() method call. There are also a couple of slight API changes to properly obtain the request host and bytebuf.


