### PR TITLE
Release 2.0.0.Final with updated dependencies and Java 25 support

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,13 +53,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
           java-version: |
-            11
             17
             21
             25
             26
       - name: Build and Test on ${{ matrix.os }}
-        run: ${{ env.MVN_CMD }} clean install '-Djava11.home=${{env.JAVA_HOME_11_X64}}' '-Djava17.home=${{env.JAVA_HOME_17_X64}}' '-Djava21.home=${{env.JAVA_HOME_21_X64}}' '-Djava25.home=${{env.JAVA_HOME_25_X64}}'
+        run: ${{ env.MVN_CMD }} clean install '-Djava17.home=${{env.JAVA_HOME_17_X64}}' '-Djava21.home=${{env.JAVA_HOME_21_X64}}' '-Djava25.home=${{env.JAVA_HOME_25_X64}}'
       - name: Upload test logs for failed run
         uses: actions/upload-artifact@v7
         if: failure()

--- a/.github/workflows/resteasy-build.yml
+++ b/.github/workflows/resteasy-build.yml
@@ -30,9 +30,9 @@ env:
 
 jobs:
   resteasy-build:
-    uses: resteasy/resteasy/.github/workflows/shared-resteasy-build.yml@6.2
+    uses: resteasy/resteasy/.github/workflows/shared-resteasy-build.yml@main
     with:
-      resteasy-branch: "6.2"
+      resteasy-branch: "main"
       resteasy-repo: "resteasy/resteasy"
 
   resteasy-vertx-build:
@@ -60,14 +60,13 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
           java-version: |
-            11
             17
             21
             25
             26
       - name: Build and Test RESTEasy Vert.x ${{ matrix.os }}
         run: |
-          ${{ env.MVN_CMD }} clean install '-Dversion.org.jboss.resteasy=${{ needs.resteasy-build.outputs.resteasy-version }}' '-Djava11.home=${{env.JAVA_HOME_11_X64}}' '-Djava17.home=${{env.JAVA_HOME_17_X64}}' '-Djava21.home=${{env.JAVA_HOME_21_X64}}' '-Djava25.home=${{env.JAVA_HOME_25_X64}}'
+          ${{ env.MVN_CMD }} clean install '-Dversion.org.jboss.resteasy=${{ needs.resteasy-build.outputs.resteasy-version }}' '-Djava17.home=${{env.JAVA_HOME_17_X64}}' '-Djava21.home=${{env.JAVA_HOME_21_X64}}' '-Djava25.home=${{env.JAVA_HOME_25_X64}}'
       - name: Upload test logs for failed run
         uses: actions/upload-artifact@v7
         if: failure()

--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,8 @@ Issues are kept in https://github.com/resteasy/resteasy-vertx/issues[GitHub Issu
 
 == Build
 
-Currently, RESTEasy Vert.x requires JDK 17+ to compile, but compiles to Java 11 bytecode.
+Currently, RESTEasy Vert.x requires JDK 17+ to compile and produces Java 17 bytecode. It is built and tested on JDK
+17, 21, 25 and 26 (see https://github.com/resteasy/resteasy-vertx/actions/workflows/main-build.yml[the CI workflow]).
 
 If you want to build the project without running the tests, you need to pull down a clone of the RESTEasy repository and
 run:

--- a/bom/bom/pom.xml
+++ b/bom/bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>dev.resteasy.vertx</groupId>
         <artifactId>resteasy-vertx-parent</artifactId>
-        <version>2.0.0.Beta2-SNAPSHOT</version>
+        <version>2.0.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -24,12 +24,12 @@
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-embedded-server</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-client</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/bom/project-bom/pom.xml
+++ b/bom/project-bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>dev.resteasy.vertx</groupId>
         <artifactId>resteasy-vertx-parent</artifactId>
-        <version>2.0.0.Beta2-SNAPSHOT</version>
+        <version>2.0.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -20,8 +20,8 @@
 
     <properties>
         <!-- Dependency versions -->
-        <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.io.netty.netty>4.2.16.Final</version.io.netty.netty>
+        <version.jakarta.ee>11.0.0</version.jakarta.ee>
+        <version.io.netty.netty>4.2.17.Final</version.io.netty.netty>
         <version.org.jboss.logging>3.6.3.Final</version.org.jboss.logging>
     </properties>
 
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/bom/test-bom/pom.xml
+++ b/bom/test-bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>dev.resteasy.vertx</groupId>
         <artifactId>resteasy-vertx-parent</artifactId>
-        <version>2.0.0.Beta2-SNAPSHOT</version>
+        <version>2.0.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -19,9 +19,10 @@
     <name>RESTEasy Vert.x: Test BOM</name>
 
     <properties>
-        <version.org.bouncycastle>1.84</version.org.bouncycastle>
+        <version.org.bouncycastle>1.85</version.org.bouncycastle>
         <version.org.eclipse.parsson>1.1.9</version.org.eclipse.parsson>
-        <version.org.junit>5.13.4</version.org.junit>
+        <version.org.junit>6.1.3</version.org.junit>
+        <version.junit4>4.13.2</version.junit4>
     </properties>
 
     <dependencyManagement>
@@ -30,7 +31,7 @@
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-project-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -40,6 +41,13 @@
                 <version>${version.org.junit}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- The vertx-core tests jar requires JUnit 4 for its test utilities -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit4}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>dev.resteasy.vertx</groupId>
         <artifactId>resteasy-vertx-parent</artifactId>
-        <version>2.0.0.Beta2-SNAPSHOT</version>
+        <version>2.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -27,14 +27,14 @@
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-project-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-test-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -88,6 +88,14 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-codec-classes-quic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
         </dependency>
         <dependency>
@@ -124,6 +132,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Required by the vertx-core tests jar (io.vertx.test.core.TestUtils) -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/embedded-server/pom.xml
+++ b/embedded-server/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>dev.resteasy.vertx</groupId>
         <artifactId>resteasy-vertx-parent</artifactId>
-        <version>2.0.0.Beta2-SNAPSHOT</version>
+        <version>2.0.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -27,14 +27,14 @@
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-project-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.vertx</groupId>
                 <artifactId>resteasy-vertx-test-bom</artifactId>
-                <version>2.0.0.Beta2-SNAPSHOT</version>
+                <version>2.0.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -64,6 +64,14 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-classes-quic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http3</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxContainer.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxContainer.java
@@ -52,7 +52,7 @@ public class VertxContainer {
         if (vertx != null) {
             try {
                 vertx.stop();
-            } catch (Exception e) {
+            } catch (Exception ignored) {
 
             }
         }

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -56,10 +56,10 @@ public class VertxHttpRequest extends BaseHttpRequest {
     protected Map<String, Object> attributes = new HashMap<String, Object>();
     protected VertxHttpResponse response;
     private final boolean is100ContinueExpected;
-    private VertxExecutionContext executionContext;
+    private final VertxExecutionContext executionContext;
     private final Context context;
     private volatile boolean flushed;
-    private HttpServerRequest request;
+    private final HttpServerRequest request;
 
     public VertxHttpRequest(final Context context, final HttpServerRequest request, final ResteasyUriInfo uri,
             final SynchronousDispatcher dispatcher, final VertxHttpResponse response, final boolean is100ContinueExpected) {
@@ -223,7 +223,7 @@ public class VertxHttpRequest extends BaseHttpRequest {
         class VertxHttpAsyncResponse extends AbstractAsynchronousResponse {
             private final Object responseLock = new Object();
             private long timerID = -1;
-            private VertxHttpResponse vertxResponse;
+            private final VertxHttpResponse vertxResponse;
 
             VertxHttpAsyncResponse(final SynchronousDispatcher dispatcher, final VertxHttpRequest request,
                     final VertxHttpResponse response) {
@@ -398,7 +398,7 @@ public class VertxHttpRequest extends BaseHttpRequest {
                 }
                 CompletableFuture<Void> ret = new CompletableFuture<>();
                 this.request.context.executeBlocking(() -> {
-                    try (CloseableContext newContext = ResteasyContext.addCloseableContextDataLevel(context)) {
+                    try (CloseableContext ignored = ResteasyContext.addCloseableContextDataLevel(context)) {
                         f.run();
                         return null;
                     } catch (RuntimeException e) {

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
@@ -25,10 +25,10 @@ import io.vertx.core.http.HttpServerResponse;
 public class VertxHttpResponse implements HttpResponse {
     private int status = 200;
     private OutputStream os;
-    private MultivaluedMap<String, Object> outputHeaders;
+    private final MultivaluedMap<String, Object> outputHeaders;
     final HttpServerResponse response;
     private boolean committed;
-    private ResteasyProviderFactory providerFactory;
+    private final ResteasyProviderFactory providerFactory;
     private final HttpMethod method;
     private Throwable vertxException;
     private boolean ended;

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
@@ -48,7 +48,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
     protected String root = "";
     protected SecurityDomain domain;
     private String deploymentID;
-    private EmbeddedServerHelper serverHelper = new EmbeddedServerHelper();
+    private final EmbeddedServerHelper serverHelper = new EmbeddedServerHelper();
     // default no idle timeout.
 
     public VertxJaxrsServer() {

--- a/embedded-server/src/test/java/org/jboss/resteasy/test/asyncio/SSEResource.java
+++ b/embedded-server/src/test/java/org/jboss/resteasy/test/asyncio/SSEResource.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.resteasy.test.asyncio;
 
+import java.io.IOException;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -36,15 +38,15 @@ public class SSEResource {
             public void run() {
                 SseEventSink s = sink;
                 s.send(sse.newEvent("HELLO"));
-                s.close();
+                close(s);
                 isClosed = s.isClosed();
                 if (!isClosed)
                     return;
-                s.close();
+                close(s);
                 isClosed = s.isClosed();
                 if (!isClosed)
                     return;
-                s.close();
+                close(s);
                 isClosed = s.isClosed();
                 if (!isClosed)
                     return;
@@ -60,6 +62,13 @@ public class SSEResource {
             }
         });
         t.start();
+    }
+
+    private static void close(SseEventSink sink) {
+        try {
+            sink.close();
+        } catch (IOException ignored) {
+        }
     }
 
     @GET

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>dev.resteasy.vertx</groupId>
     <artifactId>resteasy-vertx-parent</artifactId>
-    <version>2.0.0.Beta2-SNAPSHOT</version>
+    <version>2.0.0.Final</version>
     <packaging>pom</packaging>
 
     <name>RESTEasy Vert.x</name>
@@ -70,21 +70,21 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Compile to Java 11 -->
-        <maven.compiler.release>11</maven.compiler.release>
+        <!-- Compile to Java 17 -->
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- print logs to file by default -->
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <!-- maven-enforcer-plugin -->
-        <maven.min.version>3.9.0</maven.min.version>
+        <maven.min.version>3.9.16</maven.min.version>
 
         <!-- Dependency versions -->
-        <version.io.vertx>5.0.12</version.io.vertx>
+        <version.io.vertx>5.1.6</version.io.vertx>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.resteasy>6.2.16.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>7.0.3.Final</version.org.jboss.resteasy>
 
         <!-- Plugins versions -->
-        <version.spotless-maven-plugin>3.8.0</version.spotless-maven-plugin>
+        <version.spotless-maven-plugin>3.9.0</version.spotless-maven-plugin>
 
         <!-- Test options -->
         <additionalJvmArgs>-Djava.io.tmpdir=${project.build.directory}</additionalJvmArgs>


### PR DESCRIPTION
- Set the version to 2.0.0.Final for the final release of the resteasy-vertx-embedded-server and resteasy-vertx-client libraries.
- Upgrade to the latest stable dependencies: Vert.x 5.1.6, RESTEasy 7.0.3.Final (Jakarta EE 11), Netty 4.2.17.Final, JUnit 6.1.3, BouncyCastle 1.85 and Spotless 3.9.0.
- Compile to Java 17 bytecode and build/test on JDK 17, 21, 25 and 26.
- Add netty-codec-classes-quic and netty-codec-http3 required by Vert.x 5.1, and junit:junit 4.13.2 needed by the vertx-core tests jar.
- Raise maven.min.version to 3.9.16 to match the Maven wrapper.
- Fix the SSE test for jakarta.ws.rs 4.0 SseEventSink.close() which now throws IOException.
- Update the CI workflows (drop JDK 11, RESTEasy integration build on the main branch) and the README build requirements.