### PR TITLE
[92] Resume the async response when an exception is thrown from a sus…

### DIFF
--- a/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxHttpRequest.java
+++ b/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxHttpRequest.java
@@ -208,6 +208,9 @@ class VertxHttpRequest extends BaseHttpRequest {
                 throw VertxLogger.LOGGER.alreadySuspended();
             }
             wasSuspended = true;
+            if (time > 0) {
+                asyncResponse.setTimeout(time, unit);
+            }
             return asyncResponse;
         }
 

--- a/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxRoutingContextHandler.java
+++ b/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxRoutingContextHandler.java
@@ -128,10 +128,18 @@ class VertxRoutingContextHandler implements Handler<RoutingContext> {
         try {
             service(ctx, rc, vertxRequest, vertxResponse);
         } catch (Failure e) {
-            vertxResponse.setStatus(e.getErrorCode());
+            if (vertxRequest.getAsyncContext().isSuspended()) {
+                vertxRequest.getAsyncContext().getAsyncResponse().resume(e);
+            } else {
+                vertxResponse.setStatus(e.getErrorCode());
+            }
         } catch (Exception ex) {
-            vertxResponse.setStatus(500);
-            VertxLogger.LOGGER.failedRequest(ex);
+            if (vertxRequest.getAsyncContext().isSuspended()) {
+                vertxRequest.getAsyncContext().getAsyncResponse().resume(ex);
+            } else {
+                vertxResponse.setStatus(500);
+                VertxLogger.LOGGER.failedRequest(ex);
+            }
         }
 
         if (!vertxRequest.getAsyncContext().isSuspended()) {

--- a/embedded-server/src/test/java/dev/resteasy/server/vertx/async/AsyncResource.java
+++ b/embedded-server/src/test/java/dev/resteasy/server/vertx/async/AsyncResource.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
@@ -45,6 +46,13 @@ public class AsyncResource {
             }
         };
         t.start();
+    }
+
+    @GET
+    @Path("throw")
+    @Produces("text/plain")
+    public void throwWhileSuspended(@Suspended final AsyncResponse response) {
+        throw new WebApplicationException("exception without resume");
     }
 
     @GET

--- a/embedded-server/src/test/java/dev/resteasy/server/vertx/async/AsyncTest.java
+++ b/embedded-server/src/test/java/dev/resteasy/server/vertx/async/AsyncTest.java
@@ -4,12 +4,15 @@
  */
 package dev.resteasy.server.vertx.async;
 
+import java.util.concurrent.TimeUnit;
+
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import dev.resteasy.junit.extension.annotations.RequestPath;
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
@@ -29,10 +32,13 @@ public class AsyncTest {
         Assertions.assertEquals("hello", response.readEntity(String.class), "Wrong response content");
     }
 
-    /**
-     * @tpTestDetails Service unavailable test
-     * @tpSince RESTEasy 3.0.16
-     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    public void testExceptionWhileSuspended(@RestResource @RequestPath("async/throw") final WebTarget target) {
+        Response response = target.request().get();
+        Assertions.assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+    }
+
     @Test
     public void testTimeout(@RestResource @RequestPath("async/timeout") final WebTarget target) throws Exception {
         Response response = target.request().get();


### PR DESCRIPTION
…pended resource method.

Previously, if a @Suspended resource method threw an exception, the dispatch catch blocks would set the response status but never resume the async response, causing the client to hang indefinitely.

resolves #92 