### PR TITLE
Add embedded-server tests back to the resteasy-vertx-embedded-server.…

### DIFF
--- a/embedded-server/pom.xml
+++ b/embedded-server/pom.xml
@@ -140,4 +140,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>org.jboss.resteasy:resteasy-embedded-server-tests</dependenciesToScan>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxRoutingContextHandler.java
+++ b/embedded-server/src/main/java/dev/resteasy/server/vertx/VertxRoutingContextHandler.java
@@ -5,6 +5,7 @@
 package dev.resteasy.server.vertx;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
@@ -123,6 +124,8 @@ class VertxRoutingContextHandler implements Handler<RoutingContext> {
 
         if (body != null && body.length() > 0) {
             vertxRequest.setInputStream(new BufferInputStream(body));
+        } else {
+            vertxRequest.setInputStream(InputStream.nullInputStream());
         }
 
         try {


### PR DESCRIPTION
… These tests were mistakenly removed when we enabled SSL, but we really only needed to delete the exclusions.

Ensure an InputStream is always set on the request.