### PR TITLE
Ignore CDI tests in upstream RESTEasy for the embedded-server which d…

### DIFF
--- a/api/src/main/java/dev/resteasy/vertx/ssl/SslContextConverter.java
+++ b/api/src/main/java/dev/resteasy/vertx/ssl/SslContextConverter.java
@@ -45,6 +45,7 @@ public final class SslContextConverter {
     public static void configureSsl(final HttpServerOptions options, final SSLContext sslContext,
             final ClientAuth clientAuth) {
         options.setSsl(true)
+                .setUseAlpn(true)
                 .setKeyCertOptions(new SslContextKeyCertOptions())
                 .setClientAuth(clientAuth)
                 .setSslEngineOptions(createEngineOptions(sslContext));

--- a/embedded-server/pom.xml
+++ b/embedded-server/pom.xml
@@ -166,6 +166,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>org.jboss.resteasy:resteasy-embedded-server-tests</dependenciesToScan>
+                    <excludedGroups>cdi</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
…oes not support CDI. Also, ensure the client supports HTTP/2 with ALPN.